### PR TITLE
Add CentOS6 Compatibility

### DIFF
--- a/selinux/init.sls
+++ b/selinux/init.sls
@@ -7,7 +7,9 @@ selinux:
   pkg.installed:
     - pkgs:
       - policycoreutils-python
+{%- if grains['osmajorrelease'][0] == '7' %}
       - policycoreutils-devel
+{%- endif %}
 
 /etc/selinux/src:
   file.directory:
@@ -33,7 +35,7 @@ policy_{{ k }}:
     - group: root
     - mode: 600
     - contents_pillar: selinux:modules:{{ v_name }}:plain
-    
+
 
 checkmodule_{{ k }}:
   cmd:
@@ -45,7 +47,7 @@ checkmodule_{{ k }}:
       - file: /etc/selinux/src/{{ v_name }}.te
       - pkg: selinux
     - unless: if [ "$(semodule -l | awk '{ print $1 }' | grep {{ v_name }} )" == "{{ v_name }}" ]; then /bin/true; else /bin/false; fi
-      
+
 create_package_{{ k }}:
   cmd:
     - wait
@@ -65,7 +67,7 @@ install_semodule_{{ k }}:
     - require:
       - file: /etc/selinux/src/{{ v_name }}.te
     - unless: if [ "$(semodule -l | awk '{ print $1 }' | grep {{ v_name }} )" == "{{ v_name }}" ]; then /bin/true; else /bin/false; fi
-      
+
 {% endfor %}
 
 selinux-config:


### PR DESCRIPTION
On CentOS 6, the policycoreutils-devel is not available nor necessary, so I added a conditional to check for the OS Major release version (7) and install the package if the OS Major Release is 7
