### PR TITLE
Add management for application specific port configuration.

### DIFF
--- a/pillar.example.sls
+++ b/pillar.example.sls
@@ -1,18 +1,26 @@
 selinux:
   state: enforcing
   type: targeted
+  ports:
+    ssh:
+      tcp:
+        - 2224
+  ports.absent:
+    ssh:
+      tcp:
+        - 2223
   modules:
     gitlabsshkeygen:
       version: 1.0
       plain: |
         module gitlabsshkeygen 1.0;
-        
+
         require {
     	type ssh_keygen_t;
     	type init_tmp_t;
     	class file { read open };
         }
-        
+
         #============= ssh_keygen_t ==============
         allow ssh_keygen_t init_tmp_t:file open;
 
@@ -20,7 +28,7 @@ selinux:
       version: 1.0
       plain: |
         module gitlabnginx 1.0;
-        
+
         require {
     	type httpd_t;
     	type user_home_t;
@@ -31,18 +39,18 @@ selinux:
     	class file { read open };
     	class dir { search getattr };
         }
-        
+
         #============= httpd_t ==============
         allow httpd_t init_t:unix_stream_socket connectto;
-        
+
         #!!!! This avc can be allowed using one of the these booleans:
         #     httpd_read_user_content, httpd_enable_homedirs
         allow httpd_t user_home_dir_t:dir search;
-        
+
         #!!!! This avc can be allowed using one of the these booleans:
         #     httpd_read_user_content, httpd_enable_homedirs
         allow httpd_t user_home_t:dir { search getattr };
-        
+
         #!!!! This avc can be allowed using the boolean 'httpd_read_user_content'
         allow httpd_t user_home_t:file { read open };
         allow httpd_t user_home_t:sock_file write;

--- a/selinux/init.sls
+++ b/selinux/init.sls
@@ -16,6 +16,34 @@ selinux:
     - user: root
     - group: root
 
+{% for application, config in salt['pillar.get']('selinux:ports', {}).items() %}
+{% for protocol, ports in config.items() %}
+{% for port in ports %}
+selinux_{{ application }}_{{ protocol }}_port_{{ port }}:
+  cmd:
+    - run
+    - name: semanage port -a -t {{ application }}_port_t -p {{ protocol }} {{ port }}
+    - require:
+      - pkg: selinux
+    - unless: FOUND="no"; for i in $(semanage port -l | grep {{ application }}_port_t | tr -s ' ' | cut -d ' ' -f 3- | tr -d ','); do if [ "$i" == "{{ port }}" ]; then FOUND="yes"; fi; done; if [ "$FOUND" == "yes" ]; then /bin/true; else /bin/false; fi
+{% endfor %}
+{% endfor %}
+{% endfor %}
+
+{% for application, config in salt['pillar.get']('selinux:ports.absent', {}).items() %}
+{% for protocol, ports in config.items() %}
+{% for port in ports %}
+selinux_{{ application }}_{{ protocol }}_port_{{ port }}_absent:
+  cmd:
+    - run
+    - name: semanage port -d -t {{ application }}_port_t -p {{ protocol }} {{ port }}
+    - require:
+      - pkg: selinux
+    - unless: FOUND="no"; for i in $(semanage port -l | grep {{ application }}_port_t | tr -s ' ' | cut -d ' ' -f 3- | tr -d ','); do if [ "$i" == "{{ port }}" ]; then FOUND="yes"; fi; done; if [ "$FOUND" == "yes" ]; then /bin/false; else /bin/true; fi
+{% endfor %}
+{% endfor %}
+{% endfor %}
+
 {% for k, v in salt['pillar.get']('selinux:modules', {}).items() %}
   {% set v_name = v.name|default(k) %}
 


### PR DESCRIPTION
This is mostly useful for when you want to run an application on a non-standard port (like ssh) or want to add your own port labels.
