### PR TITLE
Support basic management of file context

### DIFF
--- a/pillar.example.sls
+++ b/pillar.example.sls
@@ -9,6 +9,13 @@ selinux:
     ssh:
       tcp:
         - 2223
+  fcontext:
+    /var/www/test.org/statics:
+      user: system_u
+      type: httpd_sys_rw_content_t
+  fcontext.absent:
+    - /var/www/test.org/src
+    - /var/www/test.org/tests
   modules:
     gitlabsshkeygen:
       version: 1.0

--- a/selinux/init.sls
+++ b/selinux/init.sls
@@ -44,6 +44,31 @@ selinux_{{ application }}_{{ protocol }}_port_{{ port }}_absent:
 {% endfor %}
 {% endfor %}
 
+{% for file, config in salt['pillar.get']('selinux:fcontext', {}).items() %}
+{% set parameters = [] %}
+{% if 'type' in config %}
+  {% do parameters.append('-t ' + config.type) %}
+{% endif %}
+{% if 'user' in config %}
+  {% do parameters.append('-s ' + config.user) %}
+{% endif %}
+selinux_fcontext_{{ file }}:
+  cmd:
+    - run
+    - name: semanage fcontext -a {{ ' '.join(parameters) }} {{ file }}
+    - require:
+      - pkg: selinux
+{% endfor %}
+
+{% for file in salt['pillar.get']('selinux:fcontext.absent', {}) %}
+selinux_fcontext_{{ file }}_absent:
+  cmd:
+    - run
+    - name: semanage fcontext -d {{ file }}
+    - require:
+      - pkg: selinux
+{% endfor %}
+
 {% for k, v in salt['pillar.get']('selinux:modules', {}).items() %}
   {% set v_name = v.name|default(k) %}
 


### PR DESCRIPTION
This commit adds simple management of file contexts
You can either add a file context with type and/or user, or remove one
It should be easy to extend from there with some more fcontext options if needed
