### PR TITLE
fix Jinja variable u'salt.pillar object' has no attribute 'headers'

### DIFF
--- a/selinux/files/config
+++ b/selinux/files/config
@@ -1,4 +1,4 @@
-{{pillar['headers']['salt']['file']}}
+# This file is managed by salt, do not edit
 {% set selinux  = pillar.get('selinux', {}) -%}
 # This file controls the state of SELinux on the system.
 # SELINUX= can take one of these three values:


### PR DESCRIPTION
On Centos 7 with latest salt 2018.3.2

ID: selinux-config
Function: file.managed
Name: /etc/selinux/config
Result: False
Comment: Unable to manage file: Jinja variable u'salt.pillar object' has no attribute 'headers'

Seems this pillar has been dropped in recent salt. Use a static string for "this file is managed by salt" instead.