### PR TITLE
use built in salt method to control selinux

### DIFF
--- a/selinux/init.sls
+++ b/selinux/init.sls
@@ -151,9 +151,7 @@ selinux-config:
     - template: jinja
 
 selinux-state:
-    cmd.run:
-        - name: setenforce {{ selinux.state|default('enforcing') }}
-        - unless: if [ "$(sestatus | awk '/Current mode/ { print $3 }')" = {{ selinux.state|default('enforcing') }} ]; then /bin/true; else /bin/false; fi
-
+  selinux.mode:
+  - name: {{ selinux.state|default('enforcing') }}
 
 {% endif %}


### PR DESCRIPTION
This change should function the same but will play nicer with "Disabled" mode, as when SELinux is disabled `sestatus` does not output "Current mode".

Example output:
`# sestatus`
`SELinux status:                 disabled`