### PR TITLE
add condition if fcontext for path exists

### DIFF
--- a/selinux/init.sls
+++ b/selinux/init.sls
@@ -71,7 +71,8 @@ selinux_{{ application }}_{{ protocol }}_port_{{ port }}_absent:
 selinux_fcontext_{{ file }}:
   cmd:
     - run
-    - name: /usr/sbin/semanage fcontext -a {{ ' '.join(parameters) }} "{{ file }}"
+    - name: if (/usr/sbin/semanage fcontext --list | grep "^{{ file }}"); then /usr/sbin/semanage fcontext -m {{ ' '.join(parameters) }} "{{ file }}"; else /usr/sbin/semanage fcontext -a {{ ' '.join(parameters) }} "{{ file }}" ; fi
+    - unless: (/usr/sbin/semanage fcontext --list | grep "^{{ file }}"|grep -E "{{ config.user }}:(.*)?{{ config.type }}")
     - require:
       - pkg: selinux
 {% endfor %}


### PR DESCRIPTION
CentOS-8 If I earlier defined selinux_fcontext for a path, salt state return erro.r. e.g
          ID: selinux_fcontext_/var/cache/thruk(/.*)?
    Function: cmd.run
        Name: /usr/sbin/semanage fcontext -a -t httpd_cache_t -s system_u "/var/cache/thruk(/.*)?"
      Result: False
     Comment: Command "/usr/sbin/semanage fcontext -a -t httpd_cache_t -s system_u "/var/cache/thruk(/.*)?"" run
     Started: 13:32:39.138376
    Duration: 1038.659 ms
     Changes:   
              ----------
              pid:
                  83342
              retcode:
                  1
              stderr:
                  ValueError: File context for /var/cache/thruk(/.*)? already defined