### PR TITLE
fix #13 rename policycoreutils-python to policycoreutils-python-utils

### DIFF
--- a/selinux/init.sls
+++ b/selinux/init.sls
@@ -6,7 +6,11 @@
 selinux:
   pkg.installed:
     - pkgs:
+{% if ( grains['saltversion'] >= '2017.7.0' and grains['osmajorrelease'] <= 7 ) or ( grains['saltversion'] < '2017.7.0' and grains['osmajorrelease'][0]|int <= 7 ) %}
       - policycoreutils-python
+{% else %}
+      - policycoreutils-python-utils
+{% endif %}
 {% if ( grains['saltversion'] >= '2017.7.0' and grains['osmajorrelease'] == 7 ) or ( grains['saltversion'] < '2017.7.0' and grains['osmajorrelease'][0] == '7' ) %}
       - policycoreutils-devel
 {%- endif %}


### PR DESCRIPTION
rename policycoreutils-python to policycoreutils-python-utils

This seems to be the only mandatory step to support centos/redhat 8

this fixes step 1 of #13 